### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = ">=3.11,<3.13"
 msgpack = "^1.1.0"
 # ta-lib = {path = "config/TA_Lib-0.4.32-cp311-cp311-win_amd64.whl"}
 # quantstats = "^0.0.62"
-pyautogen = "^0.2.35"
+ag2 = "^0.2.35"
 autogenstudio = "^0.1.5"
 yfinance = "^0.2.43"
 pandas = "^2.2.2"


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
